### PR TITLE
Fixes #20: Added Max. Simultaneous Download GUI option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See https://github.com/MrS0m30n3/youtube-dl-gui/blob/master/locale_build/HOWTO.m
 [wxPython](http://wxpython.org)
 
 [FFMPEG & FFPROBE](http://www.ffmpeg.org)
-**Optional (In order to conver video files to audio-only files)
+**Optional (In order to convert video files to audio-only files)
 
 ## PROJECT HOMEPAGE
 

--- a/youtube_dl_gui/optionsframe.py
+++ b/youtube_dl_gui/optionsframe.py
@@ -669,14 +669,14 @@ class ConnectionTab(TabPanel):
     def load_options(self):
         self.proxy_box.SetValue(self.opt_manager.options['proxy'])
         self.referer_box.SetValue(self.opt_manager.options['referer'])
-        self.maxsimdls_spinctrl.SetValue(self.opt_manager.options['max_downloads'])
+        self.maxsimdls_spinctrl.SetValue(self.opt_manager.options['workers_number'])
         self.retries_spinctrl.SetValue(self.opt_manager.options['retries'])
         self.useragent_box.SetValue(self.opt_manager.options['user_agent'])
 
     def save_options(self):
         self.opt_manager.options['proxy'] = self.proxy_box.GetValue()
         self.opt_manager.options['referer'] = self.referer_box.GetValue()
-        self.opt_manager.options['max_downloads'] = self.maxsimdls_spinctrl.GetValue()
+        self.opt_manager.options['workers_number'] = self.maxsimdls_spinctrl.GetValue()
         self.opt_manager.options['retries'] = self.retries_spinctrl.GetValue()
         self.opt_manager.options['user_agent'] = self.useragent_box.GetValue()
 

--- a/youtube_dl_gui/optionsframe.py
+++ b/youtube_dl_gui/optionsframe.py
@@ -607,6 +607,7 @@ class ConnectionTab(TabPanel):
 
     SPINCTRL_SIZE = (60, -1)
 
+    MAXSIMDLS_LABEL = _("Max. Simultaneous Downloads")
     RETRIES_LABEL = _("Retries")
     USERAGENT_LABEL = _("User Agent")
     REF_LABEL = _("Referer")
@@ -616,10 +617,12 @@ class ConnectionTab(TabPanel):
         super(ConnectionTab, self).__init__(*args, **kwargs)
 
         self.retries_spinctrl = self.create_spinctrl((1, 999))
+        self.maxsimdls_spinctrl = self.create_spinctrl((1, 999))
         self.useragent_box = self.create_textctrl()
         self.referer_box = self.create_textctrl()
         self.proxy_box = self.create_textctrl()
 
+        self.maxsimdls_text = self.create_statictext(self.MAXSIMDLS_LABEL)
         self.retries_text = self.create_statictext(self.RETRIES_LABEL)
         self.useragent_text = self.create_statictext(self.USERAGENT_LABEL)
         self.referer_text = self.create_statictext(self.REF_LABEL)
@@ -632,6 +635,12 @@ class ConnectionTab(TabPanel):
         vertical_sizer = wx.BoxSizer(wx.VERTICAL)
 
         vertical_sizer.AddSpacer(self.SIZE_10)
+
+        maxsimdls_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        maxsimdls_sizer.Add(self.maxsimdls_text)
+        maxsimdls_sizer.AddSpacer(self.SIZE_5)
+        maxsimdls_sizer.Add(self.maxsimdls_spinctrl)
+        vertical_sizer.Add(maxsimdls_sizer)
 
         retries_sizer = wx.BoxSizer(wx.HORIZONTAL)
         retries_sizer.Add(self.retries_text)
@@ -660,12 +669,14 @@ class ConnectionTab(TabPanel):
     def load_options(self):
         self.proxy_box.SetValue(self.opt_manager.options['proxy'])
         self.referer_box.SetValue(self.opt_manager.options['referer'])
+        self.maxsimdls_spinctrl.SetValue(self.opt_manager.options['max_downloads'])
         self.retries_spinctrl.SetValue(self.opt_manager.options['retries'])
         self.useragent_box.SetValue(self.opt_manager.options['user_agent'])
 
     def save_options(self):
         self.opt_manager.options['proxy'] = self.proxy_box.GetValue()
         self.opt_manager.options['referer'] = self.referer_box.GetValue()
+        self.opt_manager.options['max_downloads'] = self.maxsimdls_spinctrl.GetValue()
         self.opt_manager.options['retries'] = self.retries_spinctrl.GetValue()
         self.opt_manager.options['user_agent'] = self.useragent_box.GetValue()
 

--- a/youtube_dl_gui/optionsframe.py
+++ b/youtube_dl_gui/optionsframe.py
@@ -636,17 +636,23 @@ class ConnectionTab(TabPanel):
 
         vertical_sizer.AddSpacer(self.SIZE_10)
 
+        top_hor_sizer = wx.BoxSizer(wx.HORIZONTAL)
+	
+	retries_sizer = wx.BoxSizer(wx.HORIZONTAL)
+        retries_sizer.Add(self.retries_text)
+        retries_sizer.AddSpacer(self.SIZE_5)
+        retries_sizer.Add(self.retries_spinctrl)
+
         maxsimdls_sizer = wx.BoxSizer(wx.HORIZONTAL)
         maxsimdls_sizer.Add(self.maxsimdls_text)
         maxsimdls_sizer.AddSpacer(self.SIZE_5)
         maxsimdls_sizer.Add(self.maxsimdls_spinctrl)
-        vertical_sizer.Add(maxsimdls_sizer)
 
-        retries_sizer = wx.BoxSizer(wx.HORIZONTAL)
-        retries_sizer.Add(self.retries_text)
-        retries_sizer.AddSpacer(self.SIZE_5)
-        retries_sizer.Add(self.retries_spinctrl)
-        vertical_sizer.Add(retries_sizer)
+	top_hor_sizer.Add(retries_sizer)
+	top_hor_sizer.AddSpacer(self.SIZE_20)
+	top_hor_sizer.Add(maxsimdls_sizer)
+
+        vertical_sizer.Add(top_hor_sizer)
 
         vertical_sizer.AddSpacer(self.SIZE_10)
         vertical_sizer.Add(self.useragent_text)

--- a/youtube_dl_gui/optionsframe.py
+++ b/youtube_dl_gui/optionsframe.py
@@ -607,7 +607,7 @@ class ConnectionTab(TabPanel):
 
     SPINCTRL_SIZE = (60, -1)
 
-    MAXSIMDLS_LABEL = _("Max. Simultaneous Downloads")
+    MAXSIMDLS_LABEL = _("Max Simultaneous Downloads")
     RETRIES_LABEL = _("Retries")
     USERAGENT_LABEL = _("User Agent")
     REF_LABEL = _("Referer")


### PR DESCRIPTION
Now user can change how many videos are downloaded in parallel by heading over to Options-->Connnection-->Max. Simultaneous Downloads