### PR TITLE
Update index.html Windows links

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@ written in wxPython.</p>
 
 <p>Then you can call youtube-dlg from</br> the command line using "youtube-dl-gui" command or by creating a desktop launcher.</p>
 
-<h3>Windows:</h3><p>download <a href="http://code.google.com/p/youtube-dlg/">setup.exe</a></p>
+<h3>Windows:</h3><p>download <a href="https://github.com/MrS0m30n3/youtube-dl-gui/releases/download/0.3.8/youtube-dl-gui-0.3.8-win-setup.zip">setup.exe</a></p>
 
 <h2>
 <a name="requirements" class="anchor" href="#requirements"><span class="octicon octicon-link"></span></a>REQUIREMENTS</h2>
@@ -96,7 +96,7 @@ written in wxPython.</p>
             <small>Download</small>
             .tar.gz
           </a>
-          <a href="http://code.google.com/p/youtube-dlg" class="button button_win">
+          <a href="https://github.com/MrS0m30n3/youtube-dl-gui/releases/download/0.3.8/youtube-dl-gui-0.3.8-win-setup.zip" class="button button_win">
             <small>Download</small>
             Windows
           </a>


### PR DESCRIPTION
The Windows links pointed to the outdated Google Code site.
I've updated the links to point directly to the Windows setup program on the Github releases page.