### PR TITLE
Add labels for accessibility

### DIFF
--- a/youtube_dl_gui/mainframe.py
+++ b/youtube_dl_gui/mainframe.py
@@ -248,13 +248,14 @@ class MainFrame(wx.Frame):
 
         #REFACTOR Move to buttons_data
         self._settings_button = self._create_bitmap_button(self._bitmaps["settings"], (30, 30), self._on_settings)
+        self._settings_button.SetLabel("Settings")
 
         self._url_list = self._create_textctrl(wx.TE_MULTILINE | wx.TE_DONTWRAP, self._on_urllist_edit)
 
         self._folder_icon = self._create_static_bitmap(self._bitmaps["folder"], self._on_open_path)
 
         self._path_combobox = ExtComboBox(self._panel, 5, style=wx.CB_READONLY)
-        self._videoformat_combobox = CustomComboBox(self._panel, style=wx.CB_READONLY)
+        self._videoformat_combobox = CustomComboBox(self._panel, style=wx.CB_READONLY, label="Video Format")
 
         self._download_text = self._create_statictext(self.DOWNLOAD_LIST_LABEL)
         self._status_list = ListCtrl(self.STATUSLIST_COLUMNS,
@@ -272,6 +273,7 @@ class MainFrame(wx.Frame):
             if parent == wx.Button:
                 button.SetLabel(label)
             elif parent == wx.BitmapButton:
+                button.SetLabel(label)
                 button.SetToolTip(wx.ToolTip(label))
 
             if name in self._bitmaps:

--- a/youtube_dl_gui/widgets.py
+++ b/youtube_dl_gui/widgets.py
@@ -278,7 +278,7 @@ class CustomComboBox(wx.Panel):
     NAME = "customComboBox"
 
     def __init__(self, parent, id=wx.ID_ANY, value="", pos=wx.DefaultPosition,
-            size=wx.DefaultSize, choices=[], style=0, validator=wx.DefaultValidator, name=NAME):
+            size=wx.DefaultSize, choices=[], style=0, validator=wx.DefaultValidator, name=NAME, label=""):
         super(CustomComboBox, self).__init__(parent, id, pos, size, 0, name)
 
         assert style == self.CB_READONLY or style == 0
@@ -288,6 +288,7 @@ class CustomComboBox(wx.Panel):
         tc_height = self.textctrl.GetSize()[1]
 
         self.button = wx.Button(self, wx.ID_ANY, "▾", size=(tc_height, tc_height))
+        self.button.SetLabel(label)
 
         # Create the ListBoxPopup in two steps
         self.listbox = ListBoxPopup(self)


### PR DESCRIPTION
This concerns issue #202. The issue is that screen readers are not reading the tool tips and are instead looking for button labels.

If adding labels changes the visual presentation of Bitmap Buttons, or if you've already considered and rejected this approach, please disregard.