### PR TITLE
Save/load URL lists to/from text file

### DIFF
--- a/youtube_dl_gui/mainframe.py
+++ b/youtube_dl_gui/mainframe.py
@@ -1065,6 +1065,7 @@ class MainFrame(wx.Frame):
             result = True
 
         if result:
+            self.save_url_list_to_file() # save url list to file
             self.close()
 
     def close(self):
@@ -1085,6 +1086,10 @@ class MainFrame(wx.Frame):
         self.opt_manager.save_to_file()
 
         self.Destroy()
+
+    def save_url_list_to_file(self):
+        with open('url-list.txt', mode="w") as out_file:
+            out_file.writelines(self._url_list.GetValue())
 
 
 class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):

--- a/youtube_dl_gui/mainframe.py
+++ b/youtube_dl_gui/mainframe.py
@@ -789,6 +789,9 @@ class MainFrame(wx.Frame):
 
             textctrl.Bind(wx.EVT_CHAR, win_ctrla_eventhandler)
 
+        # Load url list from file
+        textctrl.AppendText(self.get_url_list_from_file())
+
         return textctrl
 
     def _create_popup(self, text, title, style):
@@ -1090,6 +1093,14 @@ class MainFrame(wx.Frame):
     def save_url_list_to_file(self):
         with open('url-list.txt', mode="w") as out_file:
             out_file.writelines(self._url_list.GetValue())
+
+    def get_url_list_from_file(self):
+        with open('url-list.txt', mode='r') as in_file:
+            urls = ""
+            for url in in_file.readlines():
+                urls += url
+
+            return urls
 
 
 class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):


### PR DESCRIPTION
Url list is saved to a text file 'url-list.txt' when the window is about to be closed.
Url list is loaded from text file 'url-list.txt' and appended to textctrl widget.
This is a suggested solution to #206.