### PR TITLE
Make program and test suite compatible with Python 3 instead of 2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtube-dlg setup file.
 
 Examples:

--- a/tests/test_ditem.py
+++ b/tests/test_ditem.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
 """Contains test cases for the DownloadItem object."""
-
-from __future__ import unicode_literals
 
 import sys
 import os.path
@@ -15,7 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 try:
     from youtube_dl_gui.downloadmanager import DownloadItem
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 
@@ -32,7 +27,8 @@ class TestItemInit(unittest.TestCase):
         self.assertEqual(ditem.stage, "Queued")
         self.assertEqual(ditem.url, url)
         self.assertEqual(ditem.options, options)
-        self.assertEqual(ditem.object_id, hash(url + unicode(options)))
+        # Python 3 has large hash; limit to C long
+        self.assertEqual(ditem.object_id, int(str(hash(url + str(options)))[:9]))
 
         self.assertEqual(ditem.path, "")
         self.assertEqual(ditem.filenames, [])

--- a/tests/test_dlist.py
+++ b/tests/test_dlist.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
 """Contains test cases for the DownloadList object."""
-
-from __future__ import unicode_literals
 
 import sys
 import os.path
@@ -13,10 +8,10 @@ PATH = os.path.realpath(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 
 try:
-    import mock
+    import unittest.mock as mock
     from youtube_dl_gui.downloadmanager import DownloadList, synchronized
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
 """Contains test cases for the parsers module."""
-
-from __future__ import unicode_literals
 
 import sys
 import os.path
@@ -15,7 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 try:
     from youtube_dl_gui.parsers import OptionsParser
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 
@@ -39,7 +34,7 @@ class TestParse(unittest.TestCase):
     def check_options_parse(self, expected_options):
         options_parser = OptionsParser()
 
-        self.assertItemsEqual(options_parser.parse(self.options_dict), expected_options)
+        self.assertEqual(sorted(options_parser.parse(self.options_dict)), sorted(expected_options))
 
     def test_parse_to_audio_requirement_bug(self):
         """Test case for the 'to_audio' requirement."""
@@ -56,7 +51,7 @@ class TestParse(unittest.TestCase):
                              "--audio-quality",
                              "9",
                              "-o",
-                             "/home/user/Workplace/test/youtube/%(title)s.%(ext)s"]
+                             os.path.join("/home/user/Workplace/test/youtube", "%(title)s.%(ext)s")]
 
         self.check_options_parse(expected_cmd_list)
 
@@ -82,7 +77,7 @@ class TestParse(unittest.TestCase):
                              "-f",
                              "mp4",
                              "-o",
-                             "/home/user/Workplace/test/youtube/%(title)s.%(ext)s",
+                             os.path.join("/home/user/Workplace/test/youtube", "%(title)s.%(ext)s"),
                              "--recode-video",
                              "mkv",
                              "--postprocessor-args",
@@ -98,7 +93,7 @@ class TestParse(unittest.TestCase):
                              "-f",
                              "mp4",
                              "-o",
-                             "/home/user/Workplace/test/youtube/%(title)s.%(ext)s",
+                             os.path.join("/home/user/Workplace/test/youtube", "%(title)s.%(ext)s"),
                              "--postprocessor-args",
                              "-y -report"]
 
@@ -112,7 +107,7 @@ class TestParse(unittest.TestCase):
                              "-f",
                              "mp4",
                              "-o",
-                             "/home/user/Workplace/test/youtube/%(title)s.%(ext)s",
+                             os.path.join("/home/user/Workplace/test/youtube", "%(title)s.%(ext)s"),
                              "--postprocessor-args",
                              "-y",
                              "-v"]
@@ -126,7 +121,7 @@ class TestParse(unittest.TestCase):
 
         expected_cmd_list = ["--newline",
                              "-o",
-                             "/home/user/Workplace/test/youtube/%(title)s.%(ext)s",
+                             os.path.join("/home/user/Workplace/test/youtube", "%(title)s.%(ext)s"),
                              "-f",
                              "(mp4)[width<1300]"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 """Contains test cases for the utils.py module."""
-
-from __future__ import unicode_literals
 
 import sys
 import os.path
@@ -13,11 +8,11 @@ PATH = os.path.realpath(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 
 try:
-    import mock
+    import unittest.mock as mock
 
     from youtube_dl_gui import utils
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 
@@ -111,70 +106,7 @@ class TestBuildCommand(unittest.TestCase):
 
         self.run_tests("youtube-dl.exe", tmpl)
 
-
-class TestConvertItem(unittest.TestCase):
-
-    """Test case for the convert_item function."""
-
-    def setUp(self):
-        self.input_list_u = ["v1", "v2", "v3"]
-        self.input_list_s = [str("v1"), str("v2"), str("v3")]
-
-        self.input_tuple_u = ("v1", "v2", "v3")
-        self.input_tuple_s = (str("v1"), str("v2"), str("v3"))
-
-        self.input_dict_u = {"k1": "v1", "k2": "v2"}
-        self.input_dict_s = {str("k1"): str("v1"), str("k2"): str("v2")}
-
-    def check_iter(self, iterable, iter_type, is_unicode):
-        check_type = unicode if is_unicode else str
-
-        iterable = utils.convert_item(iterable, is_unicode)
-
-        self.assertIsInstance(iterable, iter_type)
-
-        for item in iterable:
-            if iter_type == dict:
-                self.assertIsInstance(iterable[item], check_type)
-
-            self.assertIsInstance(item, check_type)
-
-    def test_convert_item_unicode_str(self):
-        self.assertIsInstance(utils.convert_item("test"), str)
-
-    def test_convert_item_unicode_unicode(self):
-        self.assertIsInstance(utils.convert_item("test", True), unicode)
-
-    def test_convert_item_str_unicode(self):
-        self.assertIsInstance(utils.convert_item(str("test"), True), unicode)
-
-    def test_convert_item_str_str(self):
-        self.assertIsInstance(utils.convert_item(str("test")), str)
-
-    def test_convert_item_list_empty(self):
-        self.assertEqual(len(utils.convert_item([])), 0)
-
-    def test_convert_item_dict_empty(self):
-        self.assertEqual(len(utils.convert_item({})), 0)
-
-    def test_convert_item_list_unicode_str(self):
-        self.check_iter(self.input_list_u, list, False)
-
-    def test_convert_item_list_str_unicode(self):
-        self.check_iter(self.input_list_s, list, True)
-
-    def test_convert_item_tuple_unicode_str(self):
-        self.check_iter(self.input_tuple_u, tuple, False)
-
-    def test_convert_item_tuple_str_unicode(self):
-        self.check_iter(self.input_tuple_s, tuple, True)
-
-    def test_convert_item_dict_unicode_str(self):
-        self.check_iter(self.input_dict_u, dict, False)
-
-    def test_convert_item_dict_str_unicode(self):
-        self.check_iter(self.input_dict_s, dict, True)
-
+# removed TestConvertItem for Python 3, as str is unicode
 
 class TestGetDefaultLang(unittest.TestCase):
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
 """Contains test cases for the widgets.py module."""
-
-from __future__ import unicode_literals
 
 import sys
 import os.path
@@ -15,7 +10,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(PATH)))
 
 try:
     import wx
-    import mock
+    import unittest.mock as mock
 
     from youtube_dl_gui.widgets import (
         ListBoxWithHeaders,
@@ -23,7 +18,7 @@ try:
         ListBoxPopup
     )
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 
@@ -38,7 +33,7 @@ class TestListBoxWithHeaders(unittest.TestCase):
         self.listbox = ListBoxWithHeaders(self.frame)
 
         self.listbox.add_header("Header")
-        self.listbox.add_items(["item%s" % i for i in xrange(10)])
+        self.listbox.add_items(["item%s" % i for i in range(10)])
 
     def tearDown(self):
         self.frame.Destroy()
@@ -56,24 +51,24 @@ class TestListBoxWithHeaders(unittest.TestCase):
         self.assertEqual(self.listbox.FindString("item"), wx.NOT_FOUND)
 
     def test_get_string_header(self):
-        self.assertEqual(self.listbox.GetString(0), "Header")
+        self.assertEqual(self.listbox.GetString(0).strip(), "Header")
 
     def test_get_string_item(self):
-        self.assertEqual(self.listbox.GetString(10), "item9")
+        self.assertEqual(self.listbox.GetString(10).strip(), "item9")
 
     def test_get_string_item_not_found(self):
-        self.assertEqual(self.listbox.GetString(11), "")
+        self.assertEqual(self.listbox.GetString(11).strip(), "")
 
     def test_get_string_item_negative_index(self):
-        self.assertEqual(self.listbox.GetString(-1), "")
+        self.assertEqual(self.listbox.GetString(-1).strip(), "")
 
     def test_insert_items(self):
         self.listbox.SetSelection(1)
 
         self.listbox.InsertItems(["new_item1", "new_item2"], 1)
-        self.assertEqual(self.listbox.GetString(1), "new_item1")
-        self.assertEqual(self.listbox.GetString(2), "new_item2")
-        self.assertEqual(self.listbox.GetString(3), "item0")
+        self.assertEqual(self.listbox.GetString(1).strip(), "new_item1")
+        self.assertEqual(self.listbox.GetString(2).strip(), "new_item2")
+        self.assertEqual(self.listbox.GetString(3).strip(), "item0")
 
         self.assertTrue(self.listbox.IsSelected(3))  # Old selection + 2
 
@@ -94,11 +89,11 @@ class TestListBoxWithHeaders(unittest.TestCase):
 
     def test_set_string_item(self):
         self.listbox.SetString(1, "item_mod0")
-        self.assertEqual(self.listbox.GetString(1), "item_mod0")
+        self.assertEqual(self.listbox.GetString(1).strip(), "item_mod0")
 
     def test_set_string_header(self):
         self.listbox.SetString(0, "New header")
-        self.assertEqual(self.listbox.GetString(0), "New header")
+        self.assertEqual(self.listbox.GetString(0).strip(), "New header")
 
         # Make sure that the header is not selectable
         self.listbox.SetSelection(0)
@@ -123,12 +118,12 @@ class TestListBoxWithHeaders(unittest.TestCase):
 
     def test_append(self):
         self.listbox.Append("item666")
-        self.assertEqual(self.listbox.GetString(11), "item666")
+        self.assertEqual(self.listbox.GetString(11).strip(), "item666")
 
     def test_append_items(self):
         self.listbox.AppendItems(["new_item1", "new_item2"])
-        self.assertEqual(self.listbox.GetString(11), "new_item1")
-        self.assertEqual(self.listbox.GetString(12), "new_item2")
+        self.assertEqual(self.listbox.GetString(11).strip(), "new_item1")
+        self.assertEqual(self.listbox.GetString(12).strip(), "new_item2")
 
     def test_clear(self):
         self.listbox.Clear()
@@ -136,7 +131,7 @@ class TestListBoxWithHeaders(unittest.TestCase):
 
     def test_delete(self):
         self.listbox.Delete(0)
-        self.assertEqual(self.listbox.GetString(0), "item0")
+        self.assertEqual(self.listbox.GetString(0).strip(), "item0")
 
         # Test item selection
         self.listbox.SetSelection(0)
@@ -182,7 +177,7 @@ class TestCustomComboBox(unittest.TestCase):
 
         # Call directly the ListBoxWithHeaders methods
         self.combobox.listbox.GetControl().add_header("Header")
-        self.combobox.listbox.GetControl().add_items(["item%s" % i for i in xrange(10)])
+        self.combobox.listbox.GetControl().add_items(["item%s" % i for i in range(10)])
 
     def tearDown(self):
         self.frame.Destroy()
@@ -190,7 +185,7 @@ class TestCustomComboBox(unittest.TestCase):
     def test_init(self):
         combobox = CustomComboBox(self.frame, -1, "item1", choices=["item0", "item1", "item2"])
 
-        self.assertEqual(combobox.GetValue(), "item1")
+        self.assertEqual(combobox.GetValue().strip(), "item1")
         self.assertEqual(combobox.GetCount(), 3)
         self.assertEqual(combobox.GetSelection(), 1)
 
@@ -215,27 +210,27 @@ class TestCustomComboBox(unittest.TestCase):
     def test_set_selection_item(self):
         self.combobox.SetSelection(1)
         self.assertEqual(self.combobox.GetSelection(), 1)
-        self.assertEqual(self.combobox.GetValue(), "item0")
+        self.assertEqual(self.combobox.GetValue().strip(), "item0")
 
     def test_set_selection_header(self):
         self.combobox.SetSelection(0)
         self.assertEqual(self.combobox.GetSelection(), wx.NOT_FOUND)
-        self.assertEqual(self.combobox.GetValue(), "")
+        self.assertEqual(self.combobox.GetValue().strip(), "")
 
     def test_set_string_selection_item(self):
         self.combobox.SetStringSelection("item0")
-        self.assertEqual(self.combobox.GetStringSelection(), "item0")
-        self.assertEqual(self.combobox.GetValue(), "item0")
+        self.assertEqual(self.combobox.GetStringSelection().strip(), "item0")
+        self.assertEqual(self.combobox.GetValue().strip(), "item0")
 
     def test_set_string_selection_header(self):
         self.combobox.SetStringSelection("Header")
-        self.assertEqual(self.combobox.GetStringSelection(), "")
-        self.assertEqual(self.combobox.GetValue(), "")
+        self.assertEqual(self.combobox.GetStringSelection().strip(), "")
+        self.assertEqual(self.combobox.GetValue().strip(), "")
 
     def test_set_string_selection_invalid_string(self):
         self.combobox.SetStringSelection("abcde")
-        self.assertEqual(self.combobox.GetStringSelection(), "")
-        self.assertEqual(self.combobox.GetValue(), "")
+        self.assertEqual(self.combobox.GetStringSelection().strip(), "")
+        self.assertEqual(self.combobox.GetValue().strip(), "")
 
     # wx.ItemContainer methods
 
@@ -256,13 +251,13 @@ class TestCustomComboBox(unittest.TestCase):
 
     def test_delete(self):
         self.combobox.Delete(1)
-        self.assertEqual(self.combobox.GetString(1), "item1")
+        self.assertEqual(self.combobox.GetString(1).strip(), "item1")
 
     # wx.TextEntry methods
 
     def test_get_value(self):
         self.combobox.SetValue("value")
-        self.assertEqual(self.combobox.GetValue(), "value")
+        self.assertEqual(self.combobox.GetValue().strip(), "value")
 
 
 def main():

--- a/youtube_dl_gui/__init__.py
+++ b/youtube_dl_gui/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg __init__ file.
 
 Responsible on how the package looks from the outside.
@@ -14,8 +11,6 @@ Example:
 
 """
 
-from __future__ import unicode_literals
-
 import sys
 import gettext
 import os.path
@@ -23,7 +18,7 @@ import os.path
 try:
     import wx
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 __packagename__ = "youtube_dl_gui"
@@ -69,7 +64,7 @@ if opt_manager.options['enable_log']:
 locale_dir = get_locale_file()
 
 try:
-    gettext.translation(__packagename__, locale_dir, [opt_manager.options['locale_name']]).install(unicode=True)
+    gettext.translation(__packagename__, locale_dir, [str(opt_manager.options['locale_name'])]).install(unicode=True)
 except IOError:
     opt_manager.options['locale_name'] = 'en_US'
     gettext.install(__packagename__)

--- a/youtube_dl_gui/__main__.py
+++ b/youtube_dl_gui/__main__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg __main__ file.
 
 __main__ file is a python 'executable' file which calls the youtubedlg
@@ -22,8 +19,6 @@ Example:
 
 """
 
-from __future__ import unicode_literals
-
 import sys
 
 if __package__ is None and not hasattr(sys, "frozen"):
@@ -33,7 +28,6 @@ if __package__ is None and not hasattr(sys, "frozen"):
     sys.path.append(os.path.dirname(os.path.dirname(PATH)))
 
 import youtube_dl_gui
-
 
 if __name__ == '__main__':
     youtube_dl_gui.main()

--- a/youtube_dl_gui/downloaders.py
+++ b/youtube_dl_gui/downloaders.py
@@ -1,14 +1,13 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Python module to download videos.
 
 This module contains the actual downloaders responsible
 for downloading the video files.
 
-"""
+Note:
+    downloaders.py is part of the youtubedlg package but it can be used
+    as a stand alone module for downloading videos.
 
-from __future__ import unicode_literals
+"""
 
 import re
 import os
@@ -18,7 +17,7 @@ import signal
 import subprocess
 
 from time import sleep
-from Queue import Queue
+from queue import Queue
 from threading import Thread
 
 from .utils import convert_item
@@ -35,7 +34,7 @@ class PipeReader(Thread):
 
     Args:
         queue (Queue.Queue): Python queue to store the output of the subprocess.
-
+        
     Warnings:
         All the operations are based on 'str' types. The caller has to convert
         the queued items back to 'unicode' if he needs to.
@@ -58,9 +57,9 @@ class PipeReader(Thread):
 
         while self._running:
             if self._filedescriptor is not None:
-                for line in iter(self._filedescriptor.readline, str('')):
+                for line in iter(self._filedescriptor.readline, b''):
                     # Ignore ffmpeg stderr
-                    if str('ffmpeg version') in line:
+                    if b'ffmpeg version' in line:
                         ignore_line = True
 
                     if not ignore_line:
@@ -161,13 +160,13 @@ class YoutubeDLDownloader(object):
 
         cmd = self._get_cmd(url, options)
         self._create_process(cmd)
-
+        
         if self._proc is not None:
             self._stderr_reader.attach_filedescriptor(self._proc.stderr)
 
         while self._proc_is_alive():
             stdout = self._proc.stdout.readline().rstrip()
-            stdout = convert_item(stdout, to_unicode=True)
+            stdout = convert_item(stdout, to_unicode=False)
 
             if stdout:
                 data_dict = extract_data(stdout)
@@ -178,7 +177,7 @@ class YoutubeDLDownloader(object):
         # We don't need to read stderr in real time
         while not self._stderr_queue.empty():
             stderr = self._stderr_queue.get_nowait().rstrip()
-            stderr = convert_item(stderr, to_unicode=True)
+            stderr = convert_item(stderr, to_unicode=False)
 
             self._log(stderr)
 
@@ -342,7 +341,7 @@ class YoutubeDLDownloader(object):
         # Encode command for subprocess
         # Refer to http://stackoverflow.com/a/9951851/35070
         if sys.version_info < (3, 0):
-            cmd = convert_item(cmd, to_unicode=False)
+            cmd = convert_item(cmd, to_unicode=True)
 
         try:
             self._proc = subprocess.Popen(cmd,

--- a/youtube_dl_gui/downloadmanager.py
+++ b/youtube_dl_gui/downloadmanager.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module for managing the download process.
 
 This module is responsible for managing the download process
@@ -19,8 +16,6 @@ Note:
 
 """
 
-from __future__ import unicode_literals
-
 import time
 import os.path
 
@@ -31,7 +26,6 @@ from threading import (
 )
 
 from wx import CallAfter
-from wx.lib.pubsub import setuparg1
 from wx.lib.pubsub import pub as Publisher
 
 from .parsers import OptionsParser
@@ -95,7 +89,8 @@ class DownloadItem(object):
     def __init__(self, url, options):
         self.url = url
         self.options = options
-        self.object_id = hash(url + to_string(options))
+        # Python 3 has large hash; limit to C long
+        self.object_id = int(str(hash(url + to_string(options)))[:9])
 
         self.reset()
 
@@ -166,7 +161,7 @@ class DownloadItem(object):
             if key in self.progress_stats:
                 value = stats_dict[key]
 
-                if not isinstance(value, basestring) or not value:
+                if not isinstance(value, str) or not value:
                     self.progress_stats[key] = self.default_values[key]
                 else:
                     self.progress_stats[key] = value
@@ -380,7 +375,7 @@ class DownloadManager(Thread):
         # Init the custom workers thread pool
         log_lock = None if log_manager is None else Lock()
         wparams = (opt_manager, self._youtubedl_path(), log_manager, log_lock)
-        self._workers = [Worker(*wparams) for _ in xrange(opt_manager.options["workers_number"])]
+        self._workers = [Worker(*wparams) for _ in range(opt_manager.options["workers_number"])]
 
         self.start()
 
@@ -502,7 +497,7 @@ class DownloadManager(Thread):
                     downloads using the active() method.
 
         """
-        CallAfter(Publisher.sendMessage, MANAGER_PUB_TOPIC, data)
+        CallAfter(Publisher.sendMessage, MANAGER_PUB_TOPIC, msg=data)
 
     def _check_youtubedl(self):
         """Check if youtube-dl binary exists. If not try to download it. """
@@ -755,5 +750,5 @@ class Worker(Thread):
         if signal == 'receive':
             self._wait_for_reply = True
 
-        CallAfter(Publisher.sendMessage, WORKER_PUB_TOPIC, (signal, data))
+        CallAfter(Publisher.sendMessage, WORKER_PUB_TOPIC, msg=(signal, data))
 

--- a/youtube_dl_gui/formats.py
+++ b/youtube_dl_gui/formats.py
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 import gettext
 
 from .utils import TwoWayOrderedDict as tdict

--- a/youtube_dl_gui/info.py
+++ b/youtube_dl_gui/info.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module that holds package information.
 
 Note:

--- a/youtube_dl_gui/logmanager.py
+++ b/youtube_dl_gui/logmanager.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module responsible for handling the log stuff. """
-
-from __future__ import unicode_literals
 
 import os.path
 from time import strftime
@@ -64,7 +59,7 @@ class LogManager(object):
             data (string): String to write to the log file.
 
         """
-        if isinstance(data, basestring):
+        if isinstance(data, str):
             self._write(data + '\n', 'a')
 
     def _write(self, data, mode):
@@ -85,7 +80,7 @@ class LogManager(object):
             else:
                 msg = data
 
-            log.write(msg.encode(self._encoding, 'ignore'))
+            log.write(str(msg.encode(self._encoding, 'ignore')))
 
     def _init_log(self):
         """Initialize the log file if not exist. """

--- a/youtube_dl_gui/mainframe.py
+++ b/youtube_dl_gui/mainframe.py
@@ -1,15 +1,9 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module responsible for the main app window. """
-
-from __future__ import unicode_literals
 
 import os
 import gettext
 
 import wx
-from wx.lib.pubsub import setuparg1 #NOTE Should remove deprecated
 from wx.lib.pubsub import pub as Publisher
 
 from wx.lib.mixins.listctrl import ListCtrlAutoWidthMixin
@@ -484,7 +478,7 @@ class MainFrame(wx.Frame):
             self._videoformat_combobox.add_header(_("Audio"))
             self._videoformat_combobox.add_items(aformats)
 
-        current_index = self._videoformat_combobox.FindString(FORMATS[self.opt_manager.options["selected_format"]])
+        current_index = self._videoformat_combobox.FindString(FORMATS[self.opt_manager.options["selected_format"]].strip())
 
         if current_index == wx.NOT_FOUND:
             self._videoformat_combobox.SetSelection(0)
@@ -494,7 +488,7 @@ class MainFrame(wx.Frame):
         self._update_videoformat(None)
 
     def _update_videoformat(self, event):
-        self.opt_manager.options["selected_format"] = selected_format = FORMATS[self._videoformat_combobox.GetValue()]
+        self.opt_manager.options["selected_format"] = selected_format = FORMATS[self._videoformat_combobox.GetValue().strip()]
 
         if selected_format in VIDEO_FORMATS:
             self.opt_manager.options["video_format"] = selected_format
@@ -801,7 +795,7 @@ class MainFrame(wx.Frame):
 
         top_sizer = wx.BoxSizer(wx.HORIZONTAL)
         top_sizer.Add(self._url_text, 0, wx.ALIGN_BOTTOM | wx.BOTTOM, 5)
-        top_sizer.AddSpacer((-1, -1), 1)
+        top_sizer.AddSpacer(-1)
         top_sizer.Add(self._settings_button)
         panel_sizer.Add(top_sizer, 0, wx.EXPAND)
 
@@ -809,13 +803,13 @@ class MainFrame(wx.Frame):
 
         mid_sizer = wx.BoxSizer(wx.HORIZONTAL)
         mid_sizer.Add(self._folder_icon)
-        mid_sizer.AddSpacer((3, -1))
+        mid_sizer.AddSpacer(3)
         mid_sizer.Add(self._path_combobox, 2, wx.ALIGN_CENTER_VERTICAL)
-        mid_sizer.AddSpacer((5, -1))
+        mid_sizer.AddSpacer(5)
         mid_sizer.Add(self._buttons["savepath"], flag=wx.ALIGN_CENTER_VERTICAL)
-        mid_sizer.AddSpacer((10, -1), 1)
+        mid_sizer.AddSpacer(10)
         mid_sizer.Add(self._videoformat_combobox, 1, wx.ALIGN_CENTER_VERTICAL)
-        mid_sizer.AddSpacer((5, -1))
+        mid_sizer.AddSpacer(5)
         mid_sizer.Add(self._buttons["add"], flag=wx.ALIGN_CENTER_VERTICAL)
         panel_sizer.Add(mid_sizer, 0, wx.EXPAND | wx.ALL, 10)
 
@@ -824,17 +818,17 @@ class MainFrame(wx.Frame):
 
         bottom_sizer = wx.BoxSizer(wx.HORIZONTAL)
         bottom_sizer.Add(self._buttons["delete"])
-        bottom_sizer.AddSpacer((5, -1))
+        bottom_sizer.AddSpacer(5)
         bottom_sizer.Add(self._buttons["play"])
-        bottom_sizer.AddSpacer((5, -1))
+        bottom_sizer.AddSpacer(5)
         bottom_sizer.Add(self._buttons["up"])
-        bottom_sizer.AddSpacer((5, -1))
+        bottom_sizer.AddSpacer(5)
         bottom_sizer.Add(self._buttons["down"])
-        bottom_sizer.AddSpacer((5, -1))
+        bottom_sizer.AddSpacer(5)
         bottom_sizer.Add(self._buttons["reload"])
-        bottom_sizer.AddSpacer((5, -1))
+        bottom_sizer.AddSpacer(5)
         bottom_sizer.Add(self._buttons["pause"])
-        bottom_sizer.AddSpacer((10, -1), 1)
+        bottom_sizer.AddSpacer(10)
         bottom_sizer.Add(self._buttons["start"])
         panel_sizer.Add(bottom_sizer, 0, wx.EXPAND | wx.TOP, 5)
 
@@ -913,7 +907,7 @@ class MainFrame(wx.Frame):
             See downloadmanager.Worker _talk_to_gui() method.
 
         """
-        signal, data = msg.data
+        signal, data = msg
 
         download_item = self._download_list.get_item(data["index"])
         download_item.update_stats(data)
@@ -930,7 +924,7 @@ class MainFrame(wx.Frame):
             See downloadmanager.DownloadManager _talk_to_gui() method.
 
         """
-        data = msg.data
+        data = msg
 
         if data == 'finished':
             self._print_stats()
@@ -1140,7 +1134,7 @@ class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):
         return url in self._url_list
 
     def bind_item(self, download_item):
-        self.InsertStringItem(self._list_index, download_item.url)
+        self.InsertItem(self._list_index, download_item.url)
 
         self.SetItemData(self._list_index, download_item.object_id)
 
@@ -1160,9 +1154,9 @@ class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):
                                               progress_stats["playlist_index"],
                                               progress_stats["playlist_size"])
 
-                self.SetStringItem(row, column, status)
+                self.SetItem(row, column, status)
             else:
-                self.SetStringItem(row, column, progress_stats[key])
+                self.SetItem(row, column, progress_stats[key])
 
     def clear(self):
         """Clear the ListCtrl widget & reset self._list_index and
@@ -1179,10 +1173,10 @@ class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):
         return self.GetNextItem(-1, wx.LIST_NEXT_ALL, wx.LIST_STATE_SELECTED)
 
     def get_all_selected(self):
-        return [index for index in xrange(self._list_index) if self.IsSelected(index)]
+        return [index for index in range(self._list_index) if self.IsSelected(index)]
 
     def deselect_all(self):
-        for index in xrange(self._list_index):
+        for index in range(self._list_index):
             self.Select(index, on=0)
 
     def get_next_selected(self, start=-1, reverse=False):
@@ -1198,7 +1192,7 @@ class ListCtrl(wx.ListCtrl, ListCtrlAutoWidthMixin):
         end = -1 if reverse else self._list_index
         step = -1 if reverse else 1
 
-        for index in xrange(start, end, step):
+        for index in range(start, end, step):
             if self.IsSelected(index):
                 return index
 

--- a/youtube_dl_gui/optionsframe.py
+++ b/youtube_dl_gui/optionsframe.py
@@ -1,15 +1,11 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module responsible for the options window. """
-
-from __future__ import unicode_literals
 
 import os
 import gettext
 
 import wx
-import wx.combo
+from wx import ComboBox
+from wx.adv import BitmapComboBox
 from wx.lib.art import flagart
 
 from .utils import (
@@ -98,7 +94,7 @@ class OptionsFrame(wx.Frame):
 
         buttons_sizer = wx.BoxSizer(wx.HORIZONTAL)
         buttons_sizer.Add(self.reset_button)
-        buttons_sizer.AddSpacer((5, -1))
+        buttons_sizer.AddSpacer(5)
         buttons_sizer.Add(self.close_button)
 
         main_sizer.Add(buttons_sizer, flag=wx.ALIGN_RIGHT | wx.ALL, border=5)
@@ -208,7 +204,7 @@ class TabPanel(wx.Panel):
         return textctrl
 
     def crt_combobox(self, choices, size=(-1, -1), event_handler=None):
-        combobox = wx.ComboBox(self, choices=choices, size=size, style=wx.CB_READONLY)
+        combobox = ComboBox(self, choices=choices, size=size, style=wx.CB_READONLY)
 
         if event_handler is not None:
             combobox.Bind(wx.EVT_COMBOBOX, event_handler)
@@ -216,7 +212,7 @@ class TabPanel(wx.Panel):
         return combobox
 
     def crt_bitmap_combobox(self, choices, size=(-1, -1), event_handler=None):
-        combobox = wx.combo.BitmapComboBox(self, size=size, style=wx.CB_READONLY)
+        combobox = BitmapComboBox(self, size=size, style=wx.CB_READONLY)
 
         for item in choices:
             lang_code, lang_name = item
@@ -348,7 +344,7 @@ class GeneralTab(TabPanel):
 
         custom_format_sizer = wx.BoxSizer(wx.HORIZONTAL)
         custom_format_sizer.Add(self.filename_custom_format, 1, wx.ALIGN_CENTER_VERTICAL)
-        custom_format_sizer.AddSpacer((5, -1))
+        custom_format_sizer.AddSpacer(5)
         custom_format_sizer.Add(self.filename_custom_format_button)
 
         vertical_sizer.Add(custom_format_sizer, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border=5)
@@ -363,7 +359,7 @@ class GeneralTab(TabPanel):
 
         shutdown_sizer = wx.BoxSizer(wx.HORIZONTAL)
         shutdown_sizer.Add(self.shutdown_checkbox)
-        shutdown_sizer.AddSpacer((-1, -1), 1)
+        shutdown_sizer.AddSpacer(-1)
         shutdown_sizer.Add(self.sudo_textctrl, 1)
 
         vertical_sizer.Add(shutdown_sizer, flag=wx.EXPAND | wx.LEFT | wx.RIGHT | wx.BOTTOM, border=5)
@@ -500,7 +496,7 @@ class FormatsTab(TabPanel):
 
         audio_quality_sizer = wx.BoxSizer(wx.HORIZONTAL)
         audio_quality_sizer.Add(self.audio_quality_label, flag=wx.ALIGN_CENTER_VERTICAL)
-        audio_quality_sizer.AddSpacer((20, -1))
+        audio_quality_sizer.AddSpacer(20)
         audio_quality_sizer.Add(self.audio_quality_combobox)
 
         vertical_sizer.Add(audio_quality_sizer, flag=wx.LEFT | wx.RIGHT | wx.BOTTOM, border=5)
@@ -610,7 +606,7 @@ class DownloadsTab(TabPanel):
 
         plist_and_fsize_sizer = wx.BoxSizer(wx.HORIZONTAL)
         plist_and_fsize_sizer.Add(self._build_playlist_sizer(), 1, wx.EXPAND)
-        plist_and_fsize_sizer.AddSpacer((5, -1))
+        plist_and_fsize_sizer.AddSpacer(5)
         plist_and_fsize_sizer.Add(self._build_filesize_sizer(), 1, wx.EXPAND)
 
         vertical_sizer.Add(plist_and_fsize_sizer, 1, wx.EXPAND | wx.TOP, border=5)
@@ -620,7 +616,7 @@ class DownloadsTab(TabPanel):
 
     def _build_playlist_sizer(self):
         playlist_box_sizer = wx.StaticBoxSizer(self.playlist_box, wx.VERTICAL)
-        playlist_box_sizer.AddSpacer((-1, 10))
+        playlist_box_sizer.AddSpacer(10)
 
         border = wx.GridBagSizer(5, 40)
 
@@ -760,7 +756,7 @@ class AdvancedTab(TabPanel):
         # Set up retries box
         retries_sizer = wx.BoxSizer(wx.HORIZONTAL)
         retries_sizer.Add(self.retries_label, flag=wx.ALIGN_CENTER_VERTICAL)
-        retries_sizer.AddSpacer((20, -1))
+        retries_sizer.AddSpacer(20)
         retries_sizer.Add(self.retries_spinctrl)
         vertical_sizer.Add(retries_sizer, flag=wx.ALIGN_RIGHT | wx.TOP | wx.RIGHT, border=5)
 
@@ -801,9 +797,9 @@ class AdvancedTab(TabPanel):
 
         logging_sizer = wx.BoxSizer(wx.HORIZONTAL)
         logging_sizer.Add(self.enable_log_checkbox)
-        logging_sizer.AddSpacer((-1, -1), 1)
+        logging_sizer.AddSpacer(-1)
         logging_sizer.Add(self.view_log_button)
-        logging_sizer.AddSpacer((5, -1))
+        logging_sizer.AddSpacer(5)
         logging_sizer.Add(self.clear_log_button)
 
         vertical_sizer.Add(logging_sizer, flag=wx.EXPAND | wx.ALL, border=5)
@@ -856,7 +852,7 @@ class ExtraTab(TabPanel):
         super(ExtraTab, self).__init__(*args, **kwargs)
 
         self.cmdline_args_label = self.crt_statictext(_("Youtube-dl command line options (e.g. --help)"))
-        self.cmdline_args_textctrl = self.crt_textctrl(wx.TE_MULTILINE | wx.TE_LINEWRAP)
+        self.cmdline_args_textctrl = self.crt_textctrl(wx.TE_MULTILINE)
 
         self.extra_opts_label = self.crt_statictext(_("Extra options"))
 
@@ -879,13 +875,13 @@ class ExtraTab(TabPanel):
 
         extra_opts_sizer = wx.WrapSizer()
         extra_opts_sizer.Add(self.youtube_dl_debug_checkbox)
-        extra_opts_sizer.AddSpacer((5, -1))
+        extra_opts_sizer.AddSpacer(5)
         extra_opts_sizer.Add(self.ignore_errors_checkbox)
-        extra_opts_sizer.AddSpacer((5, -1))
+        extra_opts_sizer.AddSpacer(5)
         extra_opts_sizer.Add(self.ignore_config_checkbox)
-        extra_opts_sizer.AddSpacer((5, -1))
+        extra_opts_sizer.AddSpacer(5)
         extra_opts_sizer.Add(self.no_mtime_checkbox)
-        extra_opts_sizer.AddSpacer((5, -1))
+        extra_opts_sizer.AddSpacer(5)
         extra_opts_sizer.Add(self.native_hls_checkbox)
 
         vertical_sizer.Add(extra_opts_sizer, flag=wx.ALL, border=5)

--- a/youtube_dl_gui/optionsmanager.py
+++ b/youtube_dl_gui/optionsmanager.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module to handle settings. """
-
-from __future__ import unicode_literals
 
 import os
 import json
@@ -327,12 +322,11 @@ class OptionsManager(object):
         """Save options to settings file. """
         check_path(self.config_path)
 
-        with open(self.settings_file, 'wb') as settings_file:
+        with open(self.settings_file, 'w') as settings_file:
             options = self._get_options()
             json.dump(options,
                       settings_file,
-                      indent=4,
-                      separators=(',', ': '))
+                      indent=4)
 
     def _settings_are_valid(self, settings_dictionary):
         """Check settings.json dictionary.

--- a/youtube_dl_gui/parsers.py
+++ b/youtube_dl_gui/parsers.py
@@ -1,9 +1,4 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module responsible for parsing the options. """
-
-from __future__ import unicode_literals
 
 import os.path
 

--- a/youtube_dl_gui/updatemanager.py
+++ b/youtube_dl_gui/updatemanager.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module to update youtube-dl binary.
 
 Attributes:
@@ -9,14 +6,11 @@ Attributes:
 
 """
 
-from __future__ import unicode_literals
-
 import os.path
 from threading import Thread
-from urllib2 import urlopen, URLError, HTTPError
+from urllib.request import urlopen, URLError, HTTPError
 
 from wx import CallAfter
-from wx.lib.pubsub import setuparg1
 from wx.lib.pubsub import pub as Publisher
 
 from .utils import (
@@ -93,4 +87,4 @@ class UpdateThread(Thread):
                 4) finish: The update thread is ready to join
 
         """
-        CallAfter(Publisher.sendMessage, UPDATE_PUB_TOPIC, (signal, data))
+        CallAfter(Publisher.sendMessage, UPDATE_PUB_TOPIC, msg=(signal, data))

--- a/youtube_dl_gui/utils.py
+++ b/youtube_dl_gui/utils.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
-
 """Youtubedlg module that contains util functions.
 
 Attributes:
@@ -9,8 +6,6 @@ Attributes:
     YOUTUBEDL_BIN (string): Youtube-dl binary filename.
 
 """
-
-from __future__ import unicode_literals
 
 import os
 import sys
@@ -22,7 +17,7 @@ import subprocess
 try:
     from twodict import TwoWayOrderedDict
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 from .info import __appname__
@@ -64,13 +59,13 @@ def convert_item(item, to_unicode=False):
             types back to 'str'.
 
     """
-    if to_unicode and isinstance(item, str):
+    if to_unicode and hasattr(item, 'encode'):
         # Convert str to unicode
-        return item.decode(get_encoding(), 'ignore')
-
-    if not to_unicode and isinstance(item, unicode):
-        # Convert unicode to str
         return item.encode(get_encoding(), 'ignore')
+
+    if not to_unicode and hasattr(item, 'decode'):
+        # Convert unicode to str
+        return item.decode(get_encoding(), 'ignore')
 
     if hasattr(item, '__iter__'):
         # Handle iterables
@@ -106,15 +101,16 @@ def convert_on_bounds(func):
 
 # See: https://github.com/MrS0m30n3/youtube-dl-gui/issues/57
 # Patch os functions to convert between 'str' and 'unicode' on app bounds
-os_sep = unicode(os.sep)
-os_getenv = convert_on_bounds(os.getenv)
-os_makedirs = convert_on_bounds(os.makedirs)
-os_path_isdir = convert_on_bounds(os.path.isdir)
-os_path_exists = convert_on_bounds(os.path.exists)
-os_path_dirname = convert_on_bounds(os.path.dirname)
-os_path_abspath = convert_on_bounds(os.path.abspath)
-os_path_realpath = convert_on_bounds(os.path.realpath)
-os_path_expanduser = convert_on_bounds(os.path.expanduser)
+# not needed for Python 3
+os_sep = os.sep
+os_getenv = os.getenv
+os_makedirs = os.makedirs
+os_path_isdir = os.path.isdir
+os_path_exists = os.path.exists
+os_path_dirname = os.path.dirname
+os_path_abspath = os.path.abspath
+os_path_realpath = os.path.realpath
+os_path_expanduser = os.path.expanduser
 
 # Patch locale functions
 locale_getdefaultlocale = convert_on_bounds(locale.getdefaultlocale)
@@ -382,10 +378,10 @@ def build_command(options_list, url):
 
 
 def get_default_lang():
-    """Get default language using the 'locale' module."""
-    default_lang, _ = locale_getdefaultlocale()
-
-    if not default_lang:
-        default_lang = "en_US"
-
-    return default_lang
+    """Return the language.
+    
+    Returns:
+        The chosen language if present, or a default of 'en_US' if blank.
+    
+    """
+    return locale_getdefaultlocale()[0] or 'en_US'

--- a/youtube_dl_gui/version.py
+++ b/youtube_dl_gui/version.py
@@ -1,5 +1,1 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 __version__ = '0.4'

--- a/youtube_dl_gui/widgets.py
+++ b/youtube_dl_gui/widgets.py
@@ -1,14 +1,9 @@
-#!/usr/bin/env python
-# -*- coding: UTF-8 -*-
-
-from __future__ import unicode_literals
-
 import sys
 
 try:
     import wx
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 
@@ -87,13 +82,13 @@ class ListBoxWithHeaders(wx.ListBox):
     # wx.ListBox methods
 
     def FindString(self, string):
-        index = super(ListBoxWithHeaders, self).FindString(string)
-
-        if index == wx.NOT_FOUND:
-            # This time try with prefix
-            index = super(ListBoxWithHeaders, self).FindString(self._add_prefix(string))
-
-        return index
+        # self.GetString wasn't properly finding strings that were
+        # clearly in self.GetStrings()
+        content = list(map(str.strip, self.GetStrings()))
+        try:
+            return content.index(string.strip())
+        except ValueError:
+            return -1
 
     def GetStringSelection(self):
         return self._remove_prefix(super(ListBoxWithHeaders, self).GetStringSelection())
@@ -136,7 +131,11 @@ class ListBoxWithHeaders(wx.ListBox):
     # wx.ItemContainer methods
 
     def Append(self, string):
-        super(ListBoxWithHeaders, self).Append(self._add_prefix(string))
+        if isinstance(string, str): # for strings
+            content = self._add_prefix(string)
+        else: # for lists
+            content = list(map(self._add_prefix, string))
+        super(ListBoxWithHeaders, self).Append(content)
 
     def AppendItems(self, strings):
         strings = [self._add_prefix(string) for string in strings]


### PR DESCRIPTION
There are many differences between string handling, hashing, wxPython, etc. in Python 2 and 3, so this breaks compatibility with Python 2. The test suites all succeed, and the program's features appear to work as intended.