### PR TITLE
Fixing errors on Python 3.x due to typing

### DIFF
--- a/youtube_dl_gui/__init__.py
+++ b/youtube_dl_gui/__init__.py
@@ -23,7 +23,7 @@ import os.path
 try:
     import wx
 except ImportError as error:
-    print error
+    print (error)
     sys.exit(1)
 
 __packagename__ = "youtube_dl_gui"


### PR DESCRIPTION
Python 3.x throws an error when printing the error, saying that the thing that you are printing (in this case the error) should be like I commited