### PR TITLE
added brackets to error in __init__.py

### DIFF
--- a/youtube_dl_gui/__init__.py
+++ b/youtube_dl_gui/__init__.py
@@ -23,7 +23,7 @@ import os.path
 try:
     import wx
 except ImportError as error:
-    print error
+    print(error)
     sys.exit(1)
 
 __packagename__ = "youtube_dl_gui"


### PR DESCRIPTION
Traceback (most recent call last):
  File "setup.py", line 73, in <module>
    from youtube_dl_gui import (
  File "/home/gcheok/contributions/youtube-dl-gui/youtube_dl_gui/__init__.py", line 26
    print error
          ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(error)?